### PR TITLE
feat: add config mapping for backend

### DIFF
--- a/backend/src/main/java/com/postiz/api/GreetingResource.java
+++ b/backend/src/main/java/com/postiz/api/GreetingResource.java
@@ -4,13 +4,23 @@ import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
 
 @Path("/hello")
 public class GreetingResource {
 
+    @ConfigProperty(name = "frontend.url")
+    String frontendUrl;
+
+    @ConfigProperty(name = "main.url")
+    String mainUrl;
+
+    @ConfigProperty(name = "api.limit")
+    int apiLimit;
+
     @GET
     @Produces(MediaType.TEXT_PLAIN)
     public String hello() {
-        return "Hello from Quarkus REST";
+        return "Frontend: " + frontendUrl + ", Main: " + mainUrl + ", API limit: " + apiLimit;
     }
 }

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -1,0 +1,6 @@
+# Map environment variables used in NestJS backend to Quarkus properties
+frontend.url=${FRONTEND_URL:}
+main.url=${MAIN_URL:}
+security.not-secured=${NOT_SECURED:false}
+api.limit=${API_LIMIT:30}
+quarkus.http.port=${PORT:3000}


### PR DESCRIPTION
## Summary
- map backend environment variables to `application.properties`
- expose mapped values via `@ConfigProperty`

## Testing
- `mvn -q -f backend/pom.xml test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b5d410ecf88321831c44254e980536